### PR TITLE
Bump PathKit to v1.0.1 fixing compatibility with Xcode 13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/Apodini/ApodiniTypeInformation.git", .upToNextMinor(from: "0.2.0")),
-        .package(url: "https://github.com/kylef/PathKit.git", .exact("0.9.2")),
+        .package(url: "https://github.com/kylef/PathKit.git", .upToNextMinor(from: "1.0.1")),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/omochi/FineJSON.git", .exact("1.14.0")),


### PR DESCRIPTION
## :recycle: Current situation & Problem
Currently `Package.swift` declares the dependence on [PathKit](https://github.com/kylef/PathKit) exactly on version `0.9.2`.
All versions prior to `1.0.1` are incompatible with Xcode 13 due to a changed function signature in Darwin of `strdup` (returning an optional pointer now).

For completeness, the following compile error occurs with current ApodiniMigrator version:

```
/Users/andreasbauer/XcodeProjects/ApodiniMigrator/.build/checkouts/PathKit/Sources/PathKit.swift:591:12: error: value of optional type 'UnsafeMutablePointer<CChar>?' (aka 'Optional<UnsafeMutablePointer<Int8>>') must be unwrapped to a value of type 'UnsafeMutablePointer<CChar>' (aka 'UnsafeMutablePointer<Int8>')
      free(cPattern)
           ^
/Users/andreasbauer/XcodeProjects/ApodiniMigrator/.build/checkouts/PathKit/Sources/PathKit.swift:591:12: note: coalesce using '??' to provide a default when the optional value contains 'nil'
      free(cPattern)
           ^
                    ?? <#default value#>
/Users/andreasbauer/XcodeProjects/ApodiniMigrator/.build/checkouts/PathKit/Sources/PathKit.swift:591:12: note: force-unwrap using '!' to abort execution if the optional value contains 'nil'
      free(cPattern)
           ^
                   !
error: fatalError
```


## :bulb: Proposed solution
`PathKit` was bumped to `1.0.1` which fixes compatibility with Xcode 13.

Note that the major version bump was solely due to dropping of swift 4 support (breaking change).

## :gear: Release Notes 
Fixed compatibility with Xcode 13.

## :heavy_plus_sign: Additional Information

### Related PRs
* https://github.com/kylef/PathKit/pull/80