### PR TITLE
Fixed issue with misaligned path components; fixed typo in parsing error; bump ClientSupport library

### DIFF
--- a/Sources/ApodiniMigratorCore/WebService/Endpoint/EndpointPath.swift
+++ b/Sources/ApodiniMigratorCore/WebService/Endpoint/EndpointPath.swift
@@ -43,7 +43,8 @@ public struct EndpointPath: Value, CustomStringConvertible, EndpointIdentifier {
     
     /// String representation of the path
     public var description: String {
-        Self.separator + components.sorted(by: \.key)
+        Self.separator + components
+            .sorted(by: \.key)
             .map { "\($0.value)" }
             .joined(separator: Self.separator)
     }
@@ -51,11 +52,9 @@ public struct EndpointPath: Value, CustomStringConvertible, EndpointIdentifier {
     public var rawValue: String {
         description
     }
-    
-    /// Path excluding the first component which corresponds to the version of the web service
+
     public var resourcePath: String {
         components
-            .filter { $0.key != 0 }
             .sorted(by: \.key)
             .map { "\($0.value)" }
             .joined(separator: Self.separator)

--- a/Sources/ApodiniMigratorCore/WebService/Legacy/LegacyServiceInformation.swift
+++ b/Sources/ApodiniMigratorCore/WebService/Legacy/LegacyServiceInformation.swift
@@ -10,7 +10,7 @@ import Foundation
 
 struct LegacyServiceInformation: Codable {
     enum MigrationError: Error {
-        case failedMath(path: String)
+        case failedMatch(path: String)
         case failedHostnameExtraction(path: String)
         case failedPortConversion(path: String)
     }
@@ -28,10 +28,10 @@ extension HTTPInformation {
     public init(fromLegacyServerPath serverPath: String) throws {
         let range = NSRange(serverPath.startIndex..., in: serverPath)
         // swiftlint:disable:next force_try
-        let regex = try! NSRegularExpression(pattern: "^http://(.+):([0-9]+)(/(\\w|\\d)+)?$")
+        let regex = try! NSRegularExpression(pattern: "^http://(.+):([0-9]+)(/.*)?$")
 
         guard let match = regex.firstMatch(in: serverPath, range: range) else {
-            throw LegacyServiceInformation.MigrationError.failedMath(path: serverPath)
+            throw LegacyServiceInformation.MigrationError.failedMatch(path: serverPath)
         }
 
         guard let hostname = serverPath.retrieveMatch(match: match, at: 1),

--- a/Sources/RESTMigrator/RESTMigrator.swift
+++ b/Sources/RESTMigrator/RESTMigrator.swift
@@ -132,8 +132,8 @@ public struct RESTMigrator: ApodiniMigrator.Migrator {
         }
 
         SwiftPackageFile(swiftTools: "5.5")
-            .platform(".macOS(.v12)", ".iOS(.v14)")
-            .dependency(url: "https://github.com/Apodini/ApodiniMigrator.git", ".upToNextMinor(from: \"0.1.0\")")
+            .platform(".macOS(.v11)", ".iOS(.v13)")
+            .dependency(url: "https://github.com/Apodini/ApodiniMigrator.git", ".upToNextMinor(from: \"0.2.0\")")
             .product(library: .packageName, targets: .packageName)
 
         ReadMeFile("Readme.md")

--- a/Sources/RESTMigrator/Resources/Utils/Utils.swift
+++ b/Sources/RESTMigrator/Resources/Utils/Utils.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PathKit
 import ApodiniMigratorClientSupport
 
 /// A typealias of `ApodiniMigratorDecodable`, a `Decodable` protocol
@@ -38,7 +39,7 @@ extension JSScript: Codable {}
 /// JSONValue conformance to `ApodiniMigratorCodable`
 extension JSONValue: Codable {}
 
-/// Holds distincts resource cases with the name of the resource as raw value
+/// Holds distinct resource cases with the name of the resource as raw value
 private enum Resource: String {
     /// Javascript convert methods
     case jsScripts = "js-convert-scripts"
@@ -52,7 +53,7 @@ fileprivate extension Bundle {
     func resource<D: Decodable>(_ resource: Resource) -> D {
         guard
             let path = path(forResource: resource.rawValue, ofType: "json"),
-            let instance = try? D.decode(from: path.asPath) else {
+            let instance = try? D.decode(from: Path(path)) else {
             fatalError("Resource \(resource.rawValue) is malformed")
         }
         return instance

--- a/Tests/ApodiniMigratorTests/ApodiniMigratorCore/ApodiniMigratorModelsTests.swift
+++ b/Tests/ApodiniMigratorTests/ApodiniMigratorCore/ApodiniMigratorModelsTests.swift
@@ -76,7 +76,7 @@ final class ApodiniMigratorModelsTests: ApodiniMigratorXCTestCase {
         let string2 = "/v2/{param}/users/{param}" // still considered equal, change is delegated to networking due to version change
 
         XCTAssertNotEqual(EndpointPath(string), EndpointPath(string1))
-        XCTAssertEqual(EndpointPath(string1), EndpointPath(string2))
+        XCTAssertNotEqual(EndpointPath(string1), EndpointPath(string2))
     }
     
     func testVersion() throws {

--- a/Tests/ApodiniMigratorTests/ApodiniMigratorCore/LegacyHTTPInformation.swift
+++ b/Tests/ApodiniMigratorTests/ApodiniMigratorCore/LegacyHTTPInformation.swift
@@ -1,0 +1,40 @@
+//
+// This source file is part of the Apodini open source project
+//
+// SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer and the Apodini project authors (see CONTRIBUTORS.md) <paul.schmiedmayer@tum.de>
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import XCTest
+@testable import ApodiniMigratorCore
+
+final class LegacyHTTPInformation: XCTestCase {
+    func testLegacyServerPath() throws {
+        XCTAssertEqual(
+            try HTTPInformation(fromLegacyServerPath: "http://localhost:8080"),
+            HTTPInformation(hostname: "localhost", port: 8080)
+        )
+
+        XCTAssertEqual(
+            try HTTPInformation(fromLegacyServerPath: "http://localhost:8080/"),
+            HTTPInformation(hostname: "localhost", port: 8080)
+        )
+
+        XCTAssertEqual(
+            try HTTPInformation(fromLegacyServerPath: "http://localhost:8080/asdf"),
+            HTTPInformation(hostname: "localhost", port: 8080)
+        )
+
+        XCTAssertEqual(
+            try HTTPInformation(fromLegacyServerPath: "http://localhost:8080/asdf-asda_asdawd882"),
+            HTTPInformation(hostname: "localhost", port: 8080)
+        )
+
+        XCTAssertEqual(
+            try HTTPInformation(fromLegacyServerPath: "http://127.0.0.1:8080"),
+            HTTPInformation(hostname: "127.0.0.1", port: 8080)
+        )
+    }
+}

--- a/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Auxiliary/APIFile.swift
+++ b/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Auxiliary/APIFile.swift
@@ -10,7 +10,7 @@ public enum API {}
 
 // MARK: - Endpoints
 public extension API {
-    /// API call for TestHandler at: hello
+    /// API call for TestHandler at: v1/hello
     static func sayHelloWorld(
         authorization: String? = nil,
         httpHeaders: HTTPHeaders = [:]

--- a/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/DefaultEndpointFile.swift
+++ b/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/DefaultEndpointFile.swift
@@ -7,7 +7,7 @@ import Foundation
 
 // MARK: - Endpoints
 public extension TestResponse {
-    /// API call for TestHandler at: tests/{second}
+    /// API call for TestHandler at: v1/tests/{second}
     static func testEndpoint(
         first: String,
         isDriving: String?,
@@ -27,7 +27,7 @@ public extension TestResponse {
         errors.addError(404, message: "Not found")
         
         let handler = Handler<TestResponse>(
-            path: "tests/\(second)",
+            path: "v1/tests/\(second)",
             httpMethod: .get,
             parameters: parameters,
             headers: headers,

--- a/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointAddParameterChange.swift
+++ b/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointAddParameterChange.swift
@@ -7,7 +7,7 @@ import Foundation
 
 // MARK: - Endpoints
 public extension TestResponse {
-    /// API call for TestHandler at: tests/{second}
+    /// API call for TestHandler at: v1/tests/{second}
     static func testEndpoint(
         first: String,
         isDriving: String?,
@@ -29,7 +29,7 @@ public extension TestResponse {
         errors.addError(404, message: "Not found")
         
         let handler = Handler<TestResponse>(
-            path: "tests/\(second)",
+            path: "v1/tests/\(second)",
             httpMethod: .get,
             parameters: parameters,
             headers: headers,

--- a/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointDeleteContentParameterChange.swift
+++ b/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointDeleteContentParameterChange.swift
@@ -7,7 +7,7 @@ import Foundation
 
 // MARK: - Endpoints
 public extension TestResponse {
-    /// API call for TestHandler at: tests/{second}
+    /// API call for TestHandler at: v1/tests/{second}
     static func testEndpoint(
         first: String,
         isDriving: String?,
@@ -27,7 +27,7 @@ public extension TestResponse {
         errors.addError(404, message: "Not found")
         
         let handler = Handler<TestResponse>(
-            path: "tests/\(second)",
+            path: "v1/tests/\(second)",
             httpMethod: .get,
             parameters: parameters,
             headers: headers,

--- a/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointDeleteParameterChange.swift
+++ b/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointDeleteParameterChange.swift
@@ -7,7 +7,7 @@ import Foundation
 
 // MARK: - Endpoints
 public extension TestResponse {
-    /// API call for TestHandler at: tests/{second}
+    /// API call for TestHandler at: v1/tests/{second}
     static func testEndpoint(
         first: String,
         isDriving: String?,
@@ -26,7 +26,7 @@ public extension TestResponse {
         errors.addError(404, message: "Not found")
         
         let handler = Handler<TestResponse>(
-            path: "tests/\(second)",
+            path: "v1/tests/\(second)",
             httpMethod: .get,
             parameters: parameters,
             headers: headers,

--- a/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointDeletedChange.swift
+++ b/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointDeletedChange.swift
@@ -8,7 +8,7 @@ import Foundation
 
 // MARK: - Endpoints
 public extension TestResponse {
-    /// API call for TestHandler at: tests/{second}
+    /// API call for TestHandler at: v1/tests/{second}
     @available(*, deprecated, message: "This endpoint is not available in the new version anymore. Calling this method results in a failing promise!")
     static func testEndpoint(
         first: String,

--- a/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointMultipleChanges.swift
+++ b/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointMultipleChanges.swift
@@ -7,7 +7,7 @@ import Foundation
 
 // MARK: - Endpoints
 public extension TestResponse {
-    /// API call for TestHandler at: tests/{second}/{first}
+    /// API call for TestHandler at: v1/tests/{second}/{first}
     static func testEndpoint(
         first: String,
         isDriving: String?,
@@ -28,7 +28,7 @@ public extension TestResponse {
         errors.addError(404, message: "Not found")
         
         let handler = Handler<TestResponse>(
-            path: "tests/\(second)/\(first)",
+            path: "v1/tests/\(second)/\(first)",
             httpMethod: .get,
             parameters: parameters,
             headers: headers,

--- a/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointOperationChange.swift
+++ b/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointOperationChange.swift
@@ -7,7 +7,7 @@ import Foundation
 
 // MARK: - Endpoints
 public extension TestResponse {
-    /// API call for TestHandler at: tests/{second}
+    /// API call for TestHandler at: v1/tests/{second}
     static func testEndpoint(
         first: String,
         isDriving: String?,
@@ -27,7 +27,7 @@ public extension TestResponse {
         errors.addError(404, message: "Not found")
         
         let handler = Handler<TestResponse>(
-            path: "tests/\(second)",
+            path: "v1/tests/\(second)",
             httpMethod: .post,
             parameters: parameters,
             headers: headers,

--- a/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointParameterKindAndPathChange.swift
+++ b/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointParameterKindAndPathChange.swift
@@ -7,7 +7,7 @@ import Foundation
 
 // MARK: - Endpoints
 public extension TestResponse {
-    /// API call for TestHandler at: tests/{second}/{first}
+    /// API call for TestHandler at: v1/tests/{second}/{first}
     static func testEndpoint(
         first: String,
         isDriving: String?,
@@ -26,7 +26,7 @@ public extension TestResponse {
         errors.addError(404, message: "Not found")
         
         let handler = Handler<TestResponse>(
-            path: "tests/\(second)/\(first)",
+            path: "v1/tests/\(second)/\(first)",
             httpMethod: .get,
             parameters: parameters,
             headers: headers,

--- a/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointParameterNecessityToRequiredChange.swift
+++ b/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointParameterNecessityToRequiredChange.swift
@@ -7,7 +7,7 @@ import Foundation
 
 // MARK: - Endpoints
 public extension TestResponse {
-    /// API call for TestHandler at: tests/{second}
+    /// API call for TestHandler at: v1/tests/{second}
     static func testEndpoint(
         first: String,
         isDriving: String?,
@@ -27,7 +27,7 @@ public extension TestResponse {
         errors.addError(404, message: "Not found")
         
         let handler = Handler<TestResponse>(
-            path: "tests/\(second)",
+            path: "v1/tests/\(second)",
             httpMethod: .get,
             parameters: parameters,
             headers: headers,

--- a/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointParameterTypeChange.swift
+++ b/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointParameterTypeChange.swift
@@ -7,7 +7,7 @@ import Foundation
 
 // MARK: - Endpoints
 public extension TestResponse {
-    /// API call for TestHandler at: tests/{second}
+    /// API call for TestHandler at: v1/tests/{second}
     static func testEndpoint(
         first: String,
         isDriving: String?,
@@ -27,7 +27,7 @@ public extension TestResponse {
         errors.addError(404, message: "Not found")
         
         let handler = Handler<TestResponse>(
-            path: "tests/\(second)",
+            path: "v1/tests/\(second)",
             httpMethod: .get,
             parameters: parameters,
             headers: headers,

--- a/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointPathChange.swift
+++ b/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointPathChange.swift
@@ -7,7 +7,7 @@ import Foundation
 
 // MARK: - Endpoints
 public extension TestResponse {
-    /// API call for TestHandler at: updatedTests/{second}
+    /// API call for TestHandler at: v1/updatedTests/{second}
     static func testEndpoint(
         first: String,
         isDriving: String?,
@@ -27,7 +27,7 @@ public extension TestResponse {
         errors.addError(404, message: "Not found")
         
         let handler = Handler<TestResponse>(
-            path: "updatedTests/\(second)",
+            path: "v1/updatedTests/\(second)",
             httpMethod: .get,
             parameters: parameters,
             headers: headers,

--- a/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointRenameParameterChange.swift
+++ b/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointRenameParameterChange.swift
@@ -7,7 +7,7 @@ import Foundation
 
 // MARK: - Endpoints
 public extension TestResponse {
-    /// API call for TestHandler at: tests/{second}
+    /// API call for TestHandler at: v1/tests/{second}
     static func testEndpoint(
         first: String,
         isDriving: String?,
@@ -27,7 +27,7 @@ public extension TestResponse {
         errors.addError(404, message: "Not found")
         
         let handler = Handler<TestResponse>(
-            path: "tests/\(second)",
+            path: "v1/tests/\(second)",
             httpMethod: .get,
             parameters: parameters,
             headers: headers,

--- a/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointResponseChange.swift
+++ b/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointResponseChange.swift
@@ -7,7 +7,7 @@ import Foundation
 
 // MARK: - Endpoints
 public extension TestResponse {
-    /// API call for TestHandler at: tests/{second}
+    /// API call for TestHandler at: v1/tests/{second}
     static func testEndpoint(
         first: String,
         isDriving: String?,
@@ -27,7 +27,7 @@ public extension TestResponse {
         errors.addError(404, message: "Not found")
         
         let handler = Handler<UpdatedTestResponse>(
-            path: "tests/\(second)",
+            path: "v1/tests/\(second)",
             httpMethod: .get,
             parameters: parameters,
             headers: headers,

--- a/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointWrappedContentParameter.swift
+++ b/Tests/ApodiniMigratorTests/Resources/ExpectedOutputs/Endpoint/EndpointWrappedContentParameter.swift
@@ -7,7 +7,7 @@ import Foundation
 
 // MARK: - Endpoints
 public extension Bool {
-    /// API call for someHandler at: test
+    /// API call for someHandler at: v1/test
     static func id(
         wrappedContentParameter: SomeWrappedContent,
         authorization: String? = nil,
@@ -19,7 +19,7 @@ public extension Bool {
         var errors: [ApodiniError] = []
         
         let handler = Handler<Bool>(
-            path: "test",
+            path: "v1/test",
             httpMethod: .post,
             parameters: [:],
             headers: headers,


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Fixed issue with misaligned path components; fixed typo in parsing error; bump ClientSupport library

## :recycle: Current situation & Problem

* The `typeMatch` error was incorrectly spelled
* PathComponents of endpoints were incorrectly rendered.
* REST clients are currently generated using `0.1.0` `ApodiniMigratorClientSupport`

## :bulb: Proposed solution

This PR fixes both issues and bumps `ApodiniMigratorClientSupport` to `0.2.0`

## :gear: Release Notes 
* Updated `ApodiniMigratorClientSupport` to `0.2.0`
* Fixed spelling in `typeMatch` error
* Fixed PathComponent rendering

## :heavy_plus_sign: Additional Information

I decided, for now, to not support parsing legacy `serverPaths` without port numbers for now, as this makes the regex relatively complex.

### Related PRs
- https://github.com/Apodini/ApodiniMigratorExample/pull/1

### Testing
Minor testing was added for the `LegacyHTTPInformation`

### Reviewer Nudging
--

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
