### PR TITLE
Properly classify model removals as breaking

### DIFF
--- a/Resources/ExampleDocuments/migration_guide.json
+++ b/Resources/ExampleDocuments/migration_guide.json
@@ -705,7 +705,7 @@
         {
             "type": "removal",
             "id": "CategoryStatus",
-            "breaking": false,
+            "breaking": true,
             "solvable": false
         },
         {

--- a/Sources/ApodiniMigratorCompare/Comparators/Model/ModelsComparator.swift
+++ b/Sources/ApodiniMigratorCompare/Comparators/Model/ModelsComparator.swift
@@ -51,8 +51,7 @@ struct ModelsComparator: Comparator {
 
         for removal in removalCandidates where !pairs.contains(where: { $0.contains(removal.deltaIdentifier) }) {
             results.append(.removal(
-                id: removal.deltaIdentifier,
-                breaking: false
+                id: removal.deltaIdentifier
             ))
         }
 

--- a/Tests/ApodiniMigratorTests/ApodiniMigratorCompareTests/ModelsComparatorTests.swift
+++ b/Tests/ApodiniMigratorTests/ApodiniMigratorCompareTests/ModelsComparatorTests.swift
@@ -63,7 +63,7 @@ final class ModelsComparatorTests: ApodiniMigratorXCTestCase {
         let change = try XCTUnwrap(modelChanges.first)
         XCTAssertEqual(change.id, programmingLanguages.deltaIdentifier)
         XCTAssertEqual(change.type, .removal)
-        XCTAssertEqual(change.breaking, false)
+        XCTAssertEqual(change.breaking, true)
         XCTAssertEqual(change.solvable, false)
 
         let removalChange = try XCTUnwrap(change.modeledRemovalChange)


### PR DESCRIPTION
<!--
                  
This source file is part of the Apodini open source project

SPDX-FileCopyrightText: 2019-2021 Paul Schmiedmayer <paul.schmiedmayer@tum.de>

SPDX-License-Identifier: MIT
             
-->

# Properly classify model removals as breaking

## :recycle: Current situation & Problem
Currently, and with all previous versions of ApodiniMigrator, removal of models types were classified as non-breaking and unsolvable. This doesn't really fit into reality and breaks our assumption that all unsolvable changes are non-breaking.

## :bulb: Proposed solution
This PR updates the MigrationGuide classifications to consider model removals to be breaking.

## :gear: Release Notes 
* Model changes are now considered breaking.

## :heavy_plus_sign: Additional Information

### Related PRs
--

### Testing
Tests were updated.

### Reviewer Nudging
---

CC: @PSchmiedmayer 

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/Apodini/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/Apodini/.github/blob/main/CONTRIBUTING.md).
